### PR TITLE
remove (redundant?) unix.cma linking argument for 4.0{3,4} compatibility

### DIFF
--- a/ocaml-gettext/Makefile
+++ b/ocaml-gettext/Makefile
@@ -64,7 +64,6 @@ uninstall: ocaml-xgettext-uninstall
 ocaml-xgettext: $(BUILDBIN)
 	$(OCAMLC)                                                            \
            -I +camlp4 dynlink.cma camlp4lib.cma                              \
-           unix.cma                                                          \
           `$(OCAMLFIND) query -r -predicates byte gettext.extract -i-format` \
           `$(OCAMLFIND) query -r -predicates byte gettext.extract -a-format` \
           `$(OCAMLFIND) query -r -predicates byte gettext.extract -o-format` \


### PR DESCRIPTION
Under OCaml 4.03 or 4.04, compiling ocaml-gettext fails with the
following error on my machine:

```
make[1]: Entering directory '/tmp/ocaml-gettext/ocaml-gettext'
ocamlfind ocamlopt -pp 'camlp4o -I +camlp4 pa_macro.cmo -DCAMOMILE' -package "gettext.extension fileutils gettext-camomile"   -c OCamlGettext.ml
ocamlfind ocamlopt -o ocaml-gettext -pp 'camlp4o -I +camlp4 pa_macro.cmo -DCAMOMILE' -package "gettext.extension fileutils gettext-camomile" -linkpkg \
-predicates ""  OCamlGettext.cmx
/usr/bin/install -c -d /tmp/ocaml-gettext/_build/bin
/usr/bin/install -c -t /tmp/ocaml-gettext/_build/bin ocaml-gettext
ocamlfind ocamlc                                                             \
           -I +camlp4 dynlink.cma camlp4lib.cma                              \
           unix.cma                                                          \
          `ocamlfind query -r -predicates byte gettext.extract -i-format` \
          `ocamlfind query -r -predicates byte gettext.extract -a-format` \
          `ocamlfind query -r -predicates byte gettext.extract -o-format` \
           Camlp4Bin.cmo                                                     \
          -o ocaml-xgettext
File "/home/gasche/.opam/4.03.0/lib/ocaml/unix.cma(Unix)", line 1:
Warning 31: files /home/gasche/.opam/4.03.0/lib/ocaml/unix.cma(Unix) and /home/gasche/.opam/4.03.0/lib/ocaml/unix.cma(Unix) both define a module named Unix
File "/home/gasche/.opam/4.03.0/lib/ocaml/unix.cma(UnixLabels)", line 1:
Warning 31: files /home/gasche/.opam/4.03.0/lib/ocaml/unix.cma(UnixLabels) and /home/gasche/.opam/4.03.0/lib/ocaml/unix.cma(UnixLabels) both define a module named UnixLabels
File "_none_", line 1:
Error: Some fatal warnings were triggered (2 occurrences)
```

I do not understand where the issue comes from (4.03.0 becames
stricter about double-linking of bytecode modules, but I don't
understand what is the *other* source passing unix.cma to this
command-line), but I tried to remove the 'unix.cma' argument in the
last command-line option, and the build complete normally with it.

I checked that ocaml-gettext still builds with this patch under
4.01.0, and that it now correctly builds under 4.03.0 and 4.04.0.

opam-builder report:
  http://opam.ocamlpro.com/builder/html/gettext/gettext.0.3.5/5ab637029cbb7556d170f6ff5fc6134b