### PR TITLE
Make the xgettext extraction more quiet

### DIFF
--- a/libgettext-ocaml/pr_gettext.ml
+++ b/libgettext-ocaml/pr_gettext.ml
@@ -78,7 +78,6 @@ struct
       }
 
   let string_of_ocaml_string str =
-    prerr_endline str;
     Scanf.sscanf 
       (Printf.sprintf "\"%s\"" str)
       "%S"


### PR DESCRIPTION
The two commits make the extraction with `ocaml-gettext` more quiet:

- the information on untranslated strings is removed, since gives more false positives than real issues
- extracted strings are not echo'ed to stderr anymore

The two commit logs explain a bit more the reasons of both (especially the former).