### PR TITLE
add more generated files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,12 @@
+*.a
+*.cma
+*.cmi
+*.cmo
+*.cmx
+*.cmxa
+*.o
+*.so
+*_parser.output
 /_build/
 /setup.data
 /setup.log
@@ -7,6 +16,12 @@
 /configure
 /libgettext-ocaml/META
 /libgettext-ocaml/gettextConfig.ml
+/libgettext-ocaml/gettextPo_parser.mli
 /config.log
 /config.status
+/po/*.mo
 /po/fr.po.bak
+/doc/*.1
+/doc/*.5
+/ocaml-gettext/ocaml-gettext
+/ocaml-gettext/ocaml-xgettext


### PR DESCRIPTION
Make sure all the files generated during a build are properly ignored from the git status.