### PR TITLE
Fix wrong package name readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Installation
 The recommended way to install ocaml-gettext is via the [opam package manager][opam]:
 
 ```sh
-$ opam install ounit
+$ opam install gettext
 ```
 
 Documentation


### PR DESCRIPTION
In what looks like a copy-paste error, the package name is wrong in the installation instructions. 
This caused me quite a bit of head-scratching, so hopefully we can fix it.