### PR TITLE
OCaml 4.11 support

### DIFF
--- a/gettext.opam
+++ b/gettext.opam
@@ -18,6 +18,7 @@ build: [
 depends: [
   "ocaml" {>= "4.03.0"}
   "dune" {>= "1.11.0"}
+  "cppo" {build}
   "fileutils"
   "base-bytes"
   "ounit" {with-test & > "2.0.8"}

--- a/src/bin/ocaml-xgettext/dune
+++ b/src/bin/ocaml-xgettext/dune
@@ -2,4 +2,5 @@
  (name xgettext)
  (public_name ocaml-xgettext)
  (package gettext)
+ (preprocess (action (run %{bin:cppo} -V OCAML:%{ocaml_version} %{input-file})))
  (libraries compiler-libs.common gettext.base gettext.extension))

--- a/src/bin/ocaml-xgettext/xgettext.ml
+++ b/src/bin/ocaml-xgettext/xgettext.ml
@@ -121,7 +121,11 @@ let visit_expr (iterator : Ast_iterator.iterator) expr =
   | Pexp_apply
       ( { pexp_desc = Pexp_ident { Asttypes.txt = lid; _ }; _ },
         ( Asttypes.Nolabel,
+#if OCAML_VERSION >= (4, 11, 0)
+          { pexp_desc = Pexp_constant (Pconst_string (singular, _, _)); _ } )
+#else
           { pexp_desc = Pexp_constant (Pconst_string (singular, _)); _ } )
+#endif
         :: _ )
     when is_like lid [ "s_"; "f_" ] ->
       (* Add a singular / default domain string *)
@@ -129,9 +133,17 @@ let visit_expr (iterator : Ast_iterator.iterator) expr =
   | Pexp_apply
       ( { pexp_desc = Pexp_ident { Asttypes.txt = lid; _ }; _ },
         ( Asttypes.Nolabel,
+#if OCAML_VERSION >= (4, 11, 0)
+          { pexp_desc = Pexp_constant (Pconst_string (singular, _, _)); _ } )
+#else
           { pexp_desc = Pexp_constant (Pconst_string (singular, _)); _ } )
+#endif
         :: ( Asttypes.Nolabel,
+#if OCAML_VERSION >= (4, 11, 0)
+             { pexp_desc = Pexp_constant (Pconst_string (plural, _, _)); _ } )
+#else
              { pexp_desc = Pexp_constant (Pconst_string (plural, _)); _ } )
+#endif
            :: _ )
     when is_like lid [ "sn_"; "fn_" ] ->
       (* Add a plural / default domain string *)
@@ -140,7 +152,11 @@ let visit_expr (iterator : Ast_iterator.iterator) expr =
       ( { pexp_desc = Pexp_ident { Asttypes.txt = lid; _ }; _ },
         _
         :: ( Asttypes.Nolabel,
+#if OCAML_VERSION >= (4, 11, 0)
+             { pexp_desc = Pexp_constant (Pconst_string (singular, _, _)); _ } )
+#else
              { pexp_desc = Pexp_constant (Pconst_string (singular, _)); _ } )
+#endif
            :: _ )
     when is_like lid [ "gettext"; "fgettext" ] ->
       (* Add a singular / default domain string *)
@@ -149,9 +165,17 @@ let visit_expr (iterator : Ast_iterator.iterator) expr =
       ( { pexp_desc = Pexp_ident { Asttypes.txt = lid; _ }; _ },
         _
         :: ( Asttypes.Nolabel,
+#if OCAML_VERSION >= (4, 11, 0)
+             { pexp_desc = Pexp_constant (Pconst_string (domain, _, _)); _ } )
+#else
              { pexp_desc = Pexp_constant (Pconst_string (domain, _)); _ } )
+#endif
            :: ( Asttypes.Nolabel,
+#if OCAML_VERSION >= (4, 11, 0)
+                { pexp_desc = Pexp_constant (Pconst_string (singular, _, _)); _ }
+#else
                 { pexp_desc = Pexp_constant (Pconst_string (singular, _)); _ }
+#endif
               )
               :: _ )
     when is_like lid [ "dgettext"; "fdgettext"; "dcgettext"; "fdcgettext" ] ->
@@ -161,9 +185,17 @@ let visit_expr (iterator : Ast_iterator.iterator) expr =
       ( { pexp_desc = Pexp_ident { Asttypes.txt = lid; _ }; _ },
         _
         :: ( Asttypes.Nolabel,
+#if OCAML_VERSION >= (4, 11, 0)
+             { pexp_desc = Pexp_constant (Pconst_string (singular, _, _)); _ } )
+#else
              { pexp_desc = Pexp_constant (Pconst_string (singular, _)); _ } )
+#endif
            :: ( Asttypes.Nolabel,
+#if OCAML_VERSION >= (4, 11, 0)
+                { pexp_desc = Pexp_constant (Pconst_string (plural, _, _)); _ } )
+#else
                 { pexp_desc = Pexp_constant (Pconst_string (plural, _)); _ } )
+#endif
               :: _ )
     when is_like lid [ "ngettext"; "fngettext" ] ->
       (* Add a plural / default domain string *)
@@ -172,12 +204,24 @@ let visit_expr (iterator : Ast_iterator.iterator) expr =
       ( { pexp_desc = Pexp_ident { Asttypes.txt = lid; _ }; _ },
         _
         :: ( Asttypes.Nolabel,
+#if OCAML_VERSION >= (4, 11, 0)
+             { pexp_desc = Pexp_constant (Pconst_string (domain, _, _)); _ } )
+#else
              { pexp_desc = Pexp_constant (Pconst_string (domain, _)); _ } )
+#endif
            :: ( Asttypes.Nolabel,
+#if OCAML_VERSION >= (4, 11, 0)
+                { pexp_desc = Pexp_constant (Pconst_string (singular, _, _)); _ }
+#else
                 { pexp_desc = Pexp_constant (Pconst_string (singular, _)); _ }
+#endif
               )
               :: ( Asttypes.Nolabel,
+#if OCAML_VERSION >= (4, 11, 0)
+                   { pexp_desc = Pexp_constant (Pconst_string (plural, _, _)); _ }
+#else
                    { pexp_desc = Pexp_constant (Pconst_string (plural, _)); _ }
+#endif
                  )
                  :: _ )
     when is_like lid [ "dngettext"; "fdngettext"; "dcngettext"; "fdcngettext" ]


### PR DESCRIPTION
In OCaml 4.11 the type of `Pconst_string` changed, this gettext does not work anymore in this version. This PR fixes it by using cppo as a preprocessor and get different generated code depending on whether it is OCaml 4.10 and below or OCaml 4.11 and above.