### PR TITLE
Remove usage of base-bytes

### DIFF
--- a/gettext-camomile.opam
+++ b/gettext-camomile.opam
@@ -19,7 +19,6 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "dune" {>= "1.11.0"}
   "camomile"
-  "base-bytes"
   "gettext" {= version}
   "ounit" {with-test & > "2.0.8"}
   "fileutils" {with-test}

--- a/gettext-stub.opam
+++ b/gettext-stub.opam
@@ -19,7 +19,6 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "dune" {>= "1.11.0"}
   "dune-configurator"  
-  "base-bytes"
   "gettext" {= version}
   "ounit" {with-test & > "2.0.8"}
   "fileutils" {with-test}

--- a/gettext.opam
+++ b/gettext.opam
@@ -20,7 +20,6 @@ depends: [
   "dune" {>= "1.11.0"}
   "cppo" {build}
   "fileutils"
-  "base-bytes"
   "ounit" {with-test & > "2.0.8"}
 ]
 synopsis: "Internationalization library (i18n)"


### PR DESCRIPTION
It is not necessary and OCaml 4.02 (minimal version that is required for dune) comes with support for Bytes.