### PR TITLE
OCaml 5 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,9 @@
 /_build/
-/configure
+/_opam/
 /dist/
 /po/*.mo
 /po/fr.po.bak
 /test/test
 /test/tests/
 *.merlin
-/*.install
 *.swp

--- a/gettext-camomile.opam
+++ b/gettext-camomile.opam
@@ -20,7 +20,7 @@ depends: [
   "dune" {>= "1.11.0"}
   "camomile"
   "gettext" {= version}
-  "ounit" {with-test & > "2.0.8"}
+  "ounit2" {with-test & > "2.2.6"}
   "fileutils" {with-test}
 ]
 synopsis: "Internationalization library using camomile (i18n)"

--- a/gettext-camomile.opam
+++ b/gettext-camomile.opam
@@ -20,7 +20,7 @@ depends: [
   "dune" {>= "1.11.0"}
   "camomile"
   "gettext" {= version}
-  "ounit2" {with-test & > "2.2.6"}
+  "ounit2" {with-test & > "2.2.7"}
   "fileutils" {with-test}
 ]
 synopsis: "Internationalization library using camomile (i18n)"

--- a/gettext-stub.opam
+++ b/gettext-stub.opam
@@ -20,7 +20,7 @@ depends: [
   "dune" {>= "1.11.0"}
   "dune-configurator"  
   "gettext" {= version}
-  "ounit" {with-test & > "2.0.8"}
+  "ounit2" {with-test & > "2.2.6"}
   "fileutils" {with-test}
 ]
 depexts: [

--- a/gettext-stub.opam
+++ b/gettext-stub.opam
@@ -20,7 +20,7 @@ depends: [
   "dune" {>= "1.11.0"}
   "dune-configurator"  
   "gettext" {= version}
-  "ounit2" {with-test & > "2.2.6"}
+  "ounit2" {with-test & > "2.2.7"}
   "fileutils" {with-test}
 ]
 depexts: [

--- a/gettext.opam
+++ b/gettext.opam
@@ -21,6 +21,7 @@ depends: [
   "cppo" {build}
   "fileutils"
   "ounit2" {with-test & > "2.2.7"}
+  "seq" {with-test}
 ]
 synopsis: "Internationalization library (i18n)"
 description:"""

--- a/gettext.opam
+++ b/gettext.opam
@@ -20,7 +20,7 @@ depends: [
   "dune" {>= "1.11.0"}
   "cppo" {build}
   "fileutils"
-  "ounit" {with-test & > "2.0.8"}
+  "ounit2" {with-test & > "2.2.6"}
 ]
 synopsis: "Internationalization library (i18n)"
 description:"""

--- a/gettext.opam
+++ b/gettext.opam
@@ -20,7 +20,7 @@ depends: [
   "dune" {>= "1.11.0"}
   "cppo" {build}
   "fileutils"
-  "ounit2" {with-test & > "2.2.6"}
+  "ounit2" {with-test & > "2.2.7"}
 ]
 synopsis: "Internationalization library (i18n)"
 description:"""

--- a/src/lib/gettext-stub/gettextStubCompat_stubs.c
+++ b/src/lib/gettext-stub/gettextStubCompat_stubs.c
@@ -76,7 +76,7 @@ CAMLprim value gettextStubCompat_gettext(
 	value v_msgid)
 {
   CAMLparam1(v_msgid);
-  CAMLreturn(copy_string(gettext(String_val(v_msgid))));
+  CAMLreturn(caml_copy_string(gettext(String_val(v_msgid))));
 }
 
 CAMLprim value gettextStubCompat_dgettext(
@@ -85,7 +85,7 @@ CAMLprim value gettextStubCompat_dgettext(
 {
   CAMLparam2(v_domainname, v_msgid);
   CAMLreturn(
-      copy_string(
+      caml_copy_string(
         dgettext(
           String_val(v_domainname),
           String_val(v_msgid))));
@@ -98,7 +98,7 @@ CAMLprim value gettextStubCompat_dcgettext(
 {
   CAMLparam3(v_domainname, v_msgid, v_category);
   CAMLreturn(
-      copy_string(
+      caml_copy_string(
         dcgettext(
           String_val(v_domainname),
           String_val(v_msgid),
@@ -112,7 +112,7 @@ CAMLprim value gettextStubCompat_ngettext(
 {
   CAMLparam3(v_msgid1, v_msgid2, v_n);
   CAMLreturn(
-      copy_string(
+      caml_copy_string(
         ngettext(
           String_val(v_msgid1),
           String_val(v_msgid2),
@@ -127,7 +127,7 @@ CAMLprim value gettextStubCompat_dngettext(
 {
   CAMLparam4(v_domainname, v_msgid1, v_msgid2, v_n);
   CAMLreturn(
-      copy_string(
+      caml_copy_string(
         dngettext(
           String_val(v_domainname),
           String_val(v_msgid1),
@@ -158,7 +158,7 @@ CAMLprim value gettextStubCompat_dcngettext(
         "NULL string not expected at "STRINGIFY(__LINE__)" in "__FILE__);
   };
 
-  CAMLreturn(copy_string(res));
+  CAMLreturn(caml_copy_string(res));
 }
 
 CAMLprim value gettextStubCompat_textdomain(

--- a/test/common/dune
+++ b/test/common/dune
@@ -1,3 +1,3 @@
 (library
  (name common)
- (libraries gettext.base oUnit))
+ (libraries gettext.base ounit2))

--- a/test/dune
+++ b/test/dune
@@ -6,7 +6,7 @@
   ../src/bin/ocaml-xgettext/xgettext.exe
   (glob_files testdata/*)
   (glob_files testdata/fr_FR/LC_MESSAGES/*))
- (libraries oUnit str fileutils gettext.extension common)
+ (libraries ounit2 str fileutils gettext.extension common)
  (action
   (run %{test}
     -runner sequential

--- a/test/dune
+++ b/test/dune
@@ -6,7 +6,7 @@
   ../src/bin/ocaml-xgettext/xgettext.exe
   (glob_files testdata/*)
   (glob_files testdata/fr_FR/LC_MESSAGES/*))
- (libraries ounit2 str fileutils gettext.extension common)
+ (libraries ounit2 str seq fileutils gettext.extension common)
  (action
   (run %{test}
     -runner sequential

--- a/test/test-camomile/dune
+++ b/test/test-camomile/dune
@@ -4,6 +4,6 @@
  (deps
   (glob_files testdata/*)
   (glob_files ../testdata/fr_FR/LC_MESSAGES/*))
- (libraries common gettext-camomile oUnit fileutils)
+ (libraries common gettext-camomile ounit2 fileutils)
  (action
   (run %{test} -test-dir ../testdata)))

--- a/test/test-stub/dune
+++ b/test/test-stub/dune
@@ -4,6 +4,6 @@
  (deps
   (glob_files ../testdata/*)
   (glob_files ../testdata/fr_FR/LC_MESSAGES/*))
- (libraries common gettext-stub oUnit)
+ (libraries common gettext-stub ounit2)
  (action
   (run %{test} -test-dir ../testdata)))

--- a/test/test.ml
+++ b/test/test.ml
@@ -221,7 +221,7 @@ let install_test =
     Printf.sprintf "%s warning" fl_mo >:: fun ctxt ->
       let tests = make_tests ctxt in
       let out = Buffer.create 13 in
-      let capture_out strm = Stream.iter (Buffer.add_char out) strm in
+      let capture_out strm = Seq.iter (Buffer.add_char out) strm in
       let fl_mo = concat tests.test_dir fl_mo in
       let fl_dst = make_filename (tests.install_dir :: fl_dsts) in
         assert_command
@@ -392,7 +392,7 @@ let compile_ocaml =
                 []
             in
             let out = Buffer.create 13 in
-            let capture_out strm = Stream.iter (Buffer.add_char out) strm in
+            let capture_out strm = Seq.iter (Buffer.add_char out) strm in
             let match_exp_err = Str.regexp (".*"^(Str.quote exp_err)^".*") in
             assert_command
               ~exit_code:(Unix.WEXITED exp_return_code)


### PR DESCRIPTION
This PR updates the code so it should work with OCaml 5. Notably it fixes some deprecation warnings displayed in 4.14 and uses the new `Seq` API that has been introduced in OUnit 2.2.6.

However, it requires a release of OUnit2 that incorporates this fix: https://github.com/gildor478/ounit/pull/95