### PR TITLE
Compatibility with OCaml5

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+### Fixed
+- Compatibility with OCaml 5
+
 ## v0.4.2 - 2020-06-11
 
 ### Fixed

--- a/gettext.opam
+++ b/gettext.opam
@@ -20,7 +20,8 @@ depends: [
   "dune" {>= "1.11.0"}
   "cppo" {build}
   "fileutils"
-  "ounit" {with-test & > "2.0.8"}
+  "seq" {with-test}
+  "ounit" {with-test & > "2.2.6"}
 ]
 synopsis: "Internationalization library (i18n)"
 description:"""

--- a/src/lib/gettext-stub/gettextStubCompat_stubs.c
+++ b/src/lib/gettext-stub/gettextStubCompat_stubs.c
@@ -76,7 +76,7 @@ CAMLprim value gettextStubCompat_gettext(
 	value v_msgid)
 {
   CAMLparam1(v_msgid);
-  CAMLreturn(copy_string(gettext(String_val(v_msgid))));
+  CAMLreturn(caml_copy_string(gettext(String_val(v_msgid))));
 }
 
 CAMLprim value gettextStubCompat_dgettext(
@@ -85,7 +85,7 @@ CAMLprim value gettextStubCompat_dgettext(
 {
   CAMLparam2(v_domainname, v_msgid);
   CAMLreturn(
-      copy_string(
+      caml_copy_string(
         dgettext(
           String_val(v_domainname),
           String_val(v_msgid))));
@@ -98,7 +98,7 @@ CAMLprim value gettextStubCompat_dcgettext(
 {
   CAMLparam3(v_domainname, v_msgid, v_category);
   CAMLreturn(
-      copy_string(
+      caml_copy_string(
         dcgettext(
           String_val(v_domainname),
           String_val(v_msgid),
@@ -112,7 +112,7 @@ CAMLprim value gettextStubCompat_ngettext(
 {
   CAMLparam3(v_msgid1, v_msgid2, v_n);
   CAMLreturn(
-      copy_string(
+      caml_copy_string(
         ngettext(
           String_val(v_msgid1),
           String_val(v_msgid2),
@@ -127,7 +127,7 @@ CAMLprim value gettextStubCompat_dngettext(
 {
   CAMLparam4(v_domainname, v_msgid1, v_msgid2, v_n);
   CAMLreturn(
-      copy_string(
+      caml_copy_string(
         dngettext(
           String_val(v_domainname),
           String_val(v_msgid1),
@@ -158,7 +158,7 @@ CAMLprim value gettextStubCompat_dcngettext(
         "NULL string not expected at "STRINGIFY(__LINE__)" in "__FILE__);
   };
 
-  CAMLreturn(copy_string(res));
+  CAMLreturn(caml_copy_string(res));
 }
 
 CAMLprim value gettextStubCompat_textdomain(

--- a/src/tools/discover-stub/discover.ml
+++ b/src/tools/discover-stub/discover.ml
@@ -35,8 +35,8 @@ let () =
                * -- This is untested, a patch is welcome if you use MacPorts --
                * https://ports.macports.org/port/gettext/summary
                *)
-              (["-I/usr/local/include"],
-               ["-L/usr/local/lib"; "-lintl"]);
+              (["-I/opt/local/include"],
+               ["-L/opt/local/lib"; "-lintl"]);
             ]
         with Not_found ->
           C.die "no ways to compile with gettext library"

--- a/test/dune
+++ b/test/dune
@@ -6,7 +6,7 @@
   ../src/bin/ocaml-xgettext/xgettext.exe
   (glob_files testdata/*)
   (glob_files testdata/fr_FR/LC_MESSAGES/*))
- (libraries oUnit str fileutils gettext.extension common)
+ (libraries oUnit str fileutils gettext.extension common seq)
  (action
   (run %{test}
     -runner sequential

--- a/test/test.ml
+++ b/test/test.ml
@@ -221,7 +221,7 @@ let install_test =
     Printf.sprintf "%s warning" fl_mo >:: fun ctxt ->
       let tests = make_tests ctxt in
       let out = Buffer.create 13 in
-      let capture_out strm = Stream.iter (Buffer.add_char out) strm in
+      let capture_out strm = Seq.iter (Buffer.add_char out) strm in
       let fl_mo = concat tests.test_dir fl_mo in
       let fl_dst = make_filename (tests.install_dir :: fl_dsts) in
         assert_command
@@ -392,7 +392,7 @@ let compile_ocaml =
                 []
             in
             let out = Buffer.create 13 in
-            let capture_out strm = Stream.iter (Buffer.add_char out) strm in
+            let capture_out strm = Seq.iter (Buffer.add_char out) strm in
             let match_exp_err = Str.regexp (".*"^(Str.quote exp_err)^".*") in
             assert_command
               ~exit_code:(Unix.WEXITED exp_return_code)


### PR DESCRIPTION
Due to a bug on ounit2, already fixed upstream, this can only be tested by pinning to the current ounit master branch. Once that is released this package should be good to go.

There is a failure in the tests:
```
File "test/dune", line 2, characters 7-11:
2 |  (name test)
           ^^^^
............................................................................................................................................................F........
==============================================================================
Error: Test ocaml-gettext:6:POT/PO file merge test:0:test4.pot+test4.po:0:Merging.

File "/Users/mseri/code/ocaml/ocaml-gettext/_build/default/test/oUnit-Test ocaml-gettext-SURFnet-CIDR-90-145-invalid#00.log", line 629, characters 1-1:
Error: Test ocaml-gettext:6:POT/PO file merge test:0:test4.pot+test4.po:0:Merging (in the log).

Raised at OUnitAssert.assert_failure in file "src/lib/ounit2/advanced/oUnitAssert.ml", line 45, characters 2-27
Called from OUnitRunner.run_one_test.(fun) in file "src/lib/ounit2/advanced/oUnitRunner.ml", line 83, characters 13-26

Unexpected error while processing testdata/test4.po ( OUnitTest.OUnit_failure("testdata/test4.po differs from testdata/test4.po.bak") )
------------------------------------------------------------------------------
Ran: 165 tests in: 0.15 seconds.
FAILED: Cases: 165 Tried: 165 Errors: 0 Failures: 1 Skip:  0 Todo: 0 Timeouts: 0.
```

However looking at the logs I cannot see the issue and `diff testdata/test4.po testdata/test4.po.bak` is empty.

Signed-off-by: Marcello Seri <marcello.seri@gmail.com>