### PR TITLE
Update the module path for Camomile >2.0.0

### DIFF
--- a/gettext-camomile.opam
+++ b/gettext-camomile.opam
@@ -18,7 +18,7 @@ build: [
 depends: [
   "ocaml" {>= "4.03.0"}
   "dune" {>= "1.11.0"}
-  "camomile"
+  "camomile" {>= "2.0.0"}
   "gettext" {= version}
   "ounit" {with-test & > "2.0.8"}
   "fileutils" {with-test}

--- a/src/lib/gettext-camomile/gettextCamomile.ml
+++ b/src/lib/gettext-camomile/gettextCamomile.ml
@@ -20,7 +20,7 @@
 (*  USA                                                                   *)
 (**************************************************************************)
 
-open CamomileLibraryDefault.Camomile
+open Camomile
 open GettextTypes
 
 (** Error reported when something goes wrong during Camomile initialization.


### PR DESCRIPTION
Camomile 2.0.0 changed the module path — it moved `CamomileLibraryDefault.Camomile` to the root. I believe they should have kept the old path for compatibility (at least for a transitional period), but it's the way it is...

For now it's easier to make a trivial change to make packages build with new Camomile versions.

Note: Camomile 2.0.0 is only available for OCaml >=4.13, so this change will cause a de facto dependency requirement upgrade.