### PR TITLE
Do not use dune sites

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -2,7 +2,6 @@
 (name gettext)
 
 (explicit_js_mode)
-(using dune_site 0.1)
 (generate_opam_files)
 
 (source (github gildor478/ocaml-gettext))
@@ -25,7 +24,6 @@
 "\|
  )
   (depends
-    dune-site
     (ocaml (>= "4.14.0"))
     (cppo (and (>= 1.8.0) :build))
     (seq (and (>= "base") :with-test))

--- a/gettext-camomile.opam
+++ b/gettext-camomile.opam
@@ -25,11 +25,9 @@ build: [
     name
     "-j"
     jobs
-    "--promote-install-files=false"
     "@install"
     "@runtest" {with-test}
     "@doc" {with-doc}
   ]
-  ["dune" "install" "-p" name "--create-install-files" name]
 ]
 dev-repo: "git+https://github.com/gildor478/ocaml-gettext.git"

--- a/gettext-stub.opam
+++ b/gettext-stub.opam
@@ -24,12 +24,10 @@ build: [
     name
     "-j"
     jobs
-    "--promote-install-files=false"
     "@install"
     "@runtest" {with-test}
     "@doc" {with-doc}
   ]
-  ["dune" "install" "-p" name "--create-install-files" name]
 ]
 dev-repo: "git+https://github.com/gildor478/ocaml-gettext.git"
 depexts: [

--- a/gettext.opam
+++ b/gettext.opam
@@ -19,7 +19,6 @@ doc: "https://gildor478.github.io/ocaml-gettext/"
 bug-reports: "https://github.com/gildor478/ocaml-gettext/issues"
 depends: [
   "dune" {>= "3.17"}
-  "dune-site"
   "ocaml" {>= "4.14.0"}
   "cppo" {>= "1.8.0" & build}
   "seq" {>= "base" & with-test}
@@ -36,11 +35,9 @@ build: [
     name
     "-j"
     jobs
-    "--promote-install-files=false"
     "@install"
     "@runtest" {with-test}
     "@doc" {with-doc}
   ]
-  ["dune" "install" "-p" name "--create-install-files" name]
 ]
 dev-repo: "git+https://github.com/gildor478/ocaml-gettext.git"

--- a/src/lib/gettext/base/.keep-directory
+++ b/src/lib/gettext/base/.keep-directory
@@ -1,1 +1,0 @@
-# This directory contains MO files.

--- a/src/lib/gettext/base/dune
+++ b/src/lib/gettext/base/dune
@@ -4,17 +4,6 @@
 (ocamlyacc
  (modules gettextFormat_parser gettextMo_parser))
 
-(generate_sites_module
- (module gettextConfigDune)
- (sites gettext))
-
-(install
- (package gettext)
- (section
-  (site
-   (gettext locale)))
- (files .keep-directory))
-
 (rule
  (target gettextConfigGen.ml)
  (action
@@ -33,4 +22,4 @@
   GettextMo_int32
   GettextMo_lexer
   GettextMo_parser)
- (libraries dune-site fileutils))
+ (libraries fileutils))

--- a/src/lib/gettext/base/gettextConfig.ml
+++ b/src/lib/gettext/base/gettextConfig.ml
@@ -23,19 +23,12 @@
 let default_dir = GettextConfigGen.default_localedir
 
 let default_path () =
-  let dunepath =
-    match GettextConfigDune.Sites.locale with
-    | [ path ] -> [ path ]
-    | [] -> []
-    | _ -> assert false
-  in
   let envpath =
     match Sys.getenv "OCAML_LOCALEPATH" with
     | s -> String.split_on_char ':' s
     | exception Not_found -> []
   in
-  envpath @ dunepath
-  @ [ GettextConfigGen.localedir; GettextConfigGen.default_localedir ]
+  envpath @ [ GettextConfigGen.localedir; GettextConfigGen.default_localedir ]
 
 let default_codeset = ""
 


### PR DESCRIPTION
Using dune-site forces use of dune in all reverse-dependencies:

  https://github.com/gildor478/ocaml-gettext/issues/36

The use here is to add an ocaml-gettext-specific directory to the default MO search path. Remove this directory altogether. (This may break reverse dependencies.)